### PR TITLE
Find bds.config based on location of bds binary.

### DIFF
--- a/bin/RNAsik
+++ b/bin/RNAsik
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 sik_origin=`dirname "${BASH_SOURCE[0]}"`
-bds -log -reportHtml "${sik_origin}"/../src/RNAsik.bds "$@"
+bds_config="$(which bds).config"
+bds -c ${bds_config} -log -reportHtml "${sik_origin}"/../src/RNAsik.bds "$@"


### PR DESCRIPTION
This works for the default BigDataScript install location of ~/.bds/, but will also work if the bds binary is installed somewhere else an is on PATH. It relies on the convention that bds.config will always be in the same directory as the bds binary, but I see this as a good stop-gap until this wrapper script is able to accept an explicit path to the bds.config on the commandline.