### PR TITLE
Set default memory for picard SortSam, MarkDuplicates.

### DIFF
--- a/configs/sik.config
+++ b/configs/sik.config
@@ -10,3 +10,6 @@ pythonExe = python
 picardExe = picard
 qualimapExe = qualimap
 multiqcExe = multiqc
+
+# 16 Gb for picard sorting, markdups
+preProMemory = 17179869184

--- a/src/RNAsik.bds
+++ b/src/RNAsik.bds
@@ -100,7 +100,7 @@ if(!samplesMap && ( (count) || (prePro) || (exonicRate) ) ) {
     if(bamFiles.exists()) bamsList = bamFiles.dirPath("*.bam")
     else error "No bam files or bamFiles directory was found. You can pass bam files using -bamFiles /path/to/bamFiles/dir"
 }
-// sorted, reorted and marking duplicates in BAM files
+// sorted, resorted and marking duplicates in BAM files
 string[] markedBams = getMarkedBams(cmdExe, markedDupsBams, bamsList, localFastaRef, fastaDictFile)
 logit(logFile, "Pre-processed BAM files", parseList(markedBams))
 // coverage files

--- a/src/sikPrePro.bds
+++ b/src/sikPrePro.bds
@@ -8,6 +8,16 @@ string[] getMarkedBams(string{} cmdExe, string markedDupsBams, string[] bamFiles
     if(!cmdExe.hasKey("picardExe")) error "Can't get picard executable, check your config file $configFile"
     string picardExe = cmdExe{"picardExe"}
 
+    // 16 Gb RAM by default
+    int picardMemory
+    if(cmdExe.hasKey("preProMemory")) {
+        picardMemory = cmdExe{"preProMemory"}.parseInt()
+    } else {
+        picardMemory = 17179869184
+    }
+
+    if(cmdExe.hasKey("preProMemory")) picardMemory := cmdExe{"preProMemory"}
+
     for(string bamFile : bamFiles) {
         string[] sampleName = bamFile.baseName().split("_")
         string sortedName = markedDupsBams+"/"+sampleName[0]+"_sorted.bam"
@@ -16,7 +26,7 @@ string[] getMarkedBams(string{} cmdExe, string markedDupsBams, string[] bamFiles
         string mdupsName = reorderedName.swapExt(".bam", "_marked_dups.bam")
         string metricsName = reorderedName.swapExt(".bam", "_marked_dups.metrics")
 
-        dep(prePro, [mdupsName, metricsName] <- [bamFile, fastaDictFile], cpus := 6, taskName := "picard sorting "+bamFile) {
+        dep(prePro, [mdupsName, metricsName] <- [bamFile, fastaDictFile], cpus := 6, mem := picardMemory, taskName := "picard sorting "+bamFile) {
             sys $picardExe SortSam TMP_DIR=tmp/ \
                                    VALIDATION_STRINGENCY=LENIENT \
                                    CREATE_INDEX=true \


### PR DESCRIPTION
This patch sets the default memory for the picard "prePro" steps to 16 Gb. This is required when BigDataScipt runs on an HPC cluster (eg SLURM) where RAM usage is enforced. This value can be configured in sik.config if required. 16 Gb is a conservative 'high' value that should prevent jobs being killed for typical runs.