### PR TITLE
Backward compatible

### DIFF
--- a/src/RNAsik.bds
+++ b/src/RNAsik.bds
@@ -82,21 +82,21 @@ if(localGTF.extName() == "gff" || localGTF.extName() == "gff3") setGFF = true
 mkLog("gffBool", setGFF, "other", logsDir)
 // get .dict file 
 string fastaDictFile
-if(totRefFiles) fastaDictFile = totRefFiles{"dict"}
+if(totRefFiles && totRefFiles.hasKey("dict")) fastaDictFile = totRefFiles{"dict"}
 else fastaDictFile = makeDictFile(cmdExe, localFastaRef)
 mkLog("picardDictFile", fastaDictFile, "refFiles", logsDir)
 // get .chrom.sizes file 
 string chromSizes
-if(totRefFiles) chromSizes = totRefFiles{"chromSizes"}
+if(totRefFiles && totRefFiles.hasKey("chromSizes")) chromSizes = totRefFiles{"chromSizes"}
 else chromSizes = makeChromSizes(localFastaRef)
 mkLog("chromSizes", chromSizes, "refFiles", logsDir)
 string faIdx
-if(totRefFiles) faIdx = totRefFiles{"fai"}
+if(totRefFiles && totRefFiles.hasKey("fai")) faIdx = totRefFiles{"fai"}
 else faIdx = makeFaiFile(cmdExe, localFastaRef)
 mkLog("fai", faIdx, "refFiles", logsDir)
 // get genomeIdx 
 if(!align.isEmpty()) {
-    if(totRefFiles) {
+    if(totRefFiles && totRefFiles.hasKey("idx")) {
         genomeIdx = totRefFiles{"idx"}
         string chkExtn = genomeIdx.extName()
         if(!chkExtn.startsWith(align)) {

--- a/src/sikRefFiles.bds
+++ b/src/sikRefFiles.bds
@@ -104,7 +104,7 @@ string{} chkRefFiles(string refDir, string aligner){
     for(string refFile : refDir.dirPath()) {
         string extn = refFile.extName()
         if( extn == "gff" || extn == "gff3" ) extn = "gtf"
-        if(extn.startsWith(aligner)) extn = "idx"
+        if(extn.startsWith(aligner+"Idx")) extn = "idx"
         //NOTE make backwards-compatible with old RNA-sik refFiles extn ".chrom.sizes":
         if(refFile.endsWith(".chrom.sizes")) extn = "chromSizes"
         if( allowedExtn.has(extn)) {

--- a/src/sikRefFiles.bds
+++ b/src/sikRefFiles.bds
@@ -96,33 +96,26 @@ string makeChromSizes(string fastaRef) {
 
 string{} chkRefFiles(string refDir, string aligner){
     string{} totRefFiles
+    string[] clobberedRefFiles
+    string[] allowedExtn = ["gtf", "fa", "fai", "chromSizes", "dict", "idx" ]
     //NOTE can't have gziped files here even though RNAsik can handle gziped files as
     // input to -fastaRef and -gtfFile but it will unzip them localy and I can't have that
     // since I'm assuming no write permissions to refFiles directory
     for(string refFile : refDir.dirPath()) {
-	string extn = refFile.extName()
-	if(extn == "gtf" || extn == "gff" || extn == "gff3") {
-	    totRefFiles{"gtf"} = refFile
+        string extn = refFile.extName()
+        if( extn == "gff" || extn == "gff3" ) extn = "gtf"
+        if(extn.startsWith(aligner)) extn = "idx"
+        //NOTE make backwards-compatible with old RNA-sik refFiles extn ".chrom.sizes":
+        if(refFile.endsWith(".chrom.sizes")) extn = "chromSizes"
+        if( allowedExtn.has(extn)) {
+            if (totRefFiles.hasKey(extn)) clobberedRefFiles.add(totRefFiles{extn})
+            totRefFiles{extn} = refFile
         }
-	if(extn == "fa") {
-	    totRefFiles{"fa"} = refFile
-        }
-	if(extn == "fai") {
-	    totRefFiles{"fai"} = refFile
-        }
-	if(extn == "dict"){
-	    totRefFiles{"dict"} = refFile
-	}
-	if(extn == "chromSizes") {
-	    totRefFiles{"chromSizes"} = refFile
-	}
-        if(extn.startsWith(aligner)) {
-	    totRefFiles{"idx"} = refFile
-	}
     }
     //NOTE have to be strick here since we don't want to be geussing which one of multiple gtf/gff files to pick.
     string[] itemsChk = totRefFiles.values()
-    if(itemsChk.size() != 6 ) error "Too many or too little refFiles were found, '$totRefFiles'. Try using -fastaRef and -gtfFile options instead"
+    if(itemsChk.size() < 6 ) error "Too few refFiles were found, '$totRefFiles'. Try using -fastaRef and -gtfFile options instead. Maybe the refFiles dir is from an older version of RNAsik?"
+    if(clobberedRefFiles.size() > 0 ) error "Extra refFiles were found, '$clobberedRefFiles'. Ensure only one of each of these filetypes is in your refFiles directory."
 
     return totRefFiles
 }

--- a/src/sikRefFiles.bds
+++ b/src/sikRefFiles.bds
@@ -114,7 +114,7 @@ string{} chkRefFiles(string refDir, string aligner){
     }
     //NOTE have to be strick here since we don't want to be geussing which one of multiple gtf/gff files to pick.
     string[] itemsChk = totRefFiles.values()
-    if(itemsChk.size() < 6 ) error "Too few refFiles were found, '$totRefFiles'. Try using -fastaRef and -gtfFile options instead. Maybe the refFiles dir is from an older version of RNAsik?"
+    if(itemsChk.size() < 6 ) warning "\n refFiles doesnt contain full complement: '$totRefFiles'. Try using -fastaRef and -gtfFile options instead. Maybe the refFiles dir is from an older version of RNAsik?\n"
     if(clobberedRefFiles.size() > 0 ) error "Extra refFiles were found, '$clobberedRefFiles'. Ensure only one of each of these filetypes is in your refFiles directory."
 
     return totRefFiles

--- a/src/sikSTARaligner.bds
+++ b/src/sikSTARaligner.bds
@@ -9,7 +9,7 @@ string makeSTARindex(string{} cmdExe, string refFiles, string fastaRef, string g
     if(!cmdExe.hasKey("starExe")) error "Can't get STAR executable, check your config file $configFile"
     string starExe = cmdExe{"starExe"}
 
-    string genomeIdxDir = fastaRef.removeExt()+".starIdx"
+    string genomeIdxDir = fastaRef.removeExt()+"."+align+"Idx"
     if(!genomeIdxDir.exists()) genomeIdxDir.mkdir()
     
     string[] idxFiles = ["chrLength.txt", "chrNameLength.txt", "chrName.txt", "chrStart.txt", "Genome", "genomeParameters.txt", "SA", "SAindex"]

--- a/src/sikSanityCheck.bds
+++ b/src/sikSanityCheck.bds
@@ -78,17 +78,21 @@ if(!fqDir.isEmpty()) {
     if(!fqDir.isDir() && chkHttp == -1) error "-fqDir doesn't point to valid directory, check your path $fqDir"
     if(align.isEmpty() && !fastqc) error "-align and -fastqc are empty, not sure why -fqDir $fqDir was specified, add more options"
 } 
-if( !align.isEmpty() && genomeIdx.isEmpty() ) {
-    if(refFiles.isEmpty()) {
-        if(fastaRef.isEmpty()) error "You need to either specify -genomeIdx or -fastaRef or -refFiles"
+if(!align.isEmpty()){
+    if( genomeIdx.isEmpty() && refFiles.isEmpty() && fastaRef.isEmpty()){
+        error "You need to specify  either -genomeIdx, -fastaRef or -refFiles"
+    }
+    //NOTE: Should we also allow -genomeIdx as an alternative to GTF for starWithAnn?
+    if(align == "starWithAnn" && refFiles.isEmpty() && gtfFile.isEmpty()){
+        error "Usage (starWithAnn): -gtfFile /path/to/GTFfile or -refFiles /path/to/refFiles "
     }
 }
-if(align == "starWithAnn" && (refFiles.isEmpty() || gtfFile.isEmpty())) error "Usage: -gtfFile /path/to/GTFfile"
+
 if(fastqc && fqDir.isEmpty()) error "Usage: -fqDir /path/to/FASTQ/files"
 
 if(counts) {
     if(refFiles.isEmpty()) {
-        if(gtfFile.isEmpty()) error "Usage: -gtfFile /path/to/GTFfile"
+        if(gtfFile.isEmpty()) error "Usage (if using -counts): -gtfFile /path/to/GTFfile"
     }
 }
 if(prePro) {


### PR DESCRIPTION
A few improvements to how -refFiles directory is used, mainly for use with -align starWithAnn. This now differentiates between the situation where > 1 file in a file-type is give (now errors out, this was previously not tested for) and the situation where not all the 6 filetypes are given. As of the last commit of this branch, this situation just gives a warning, as many pipelines don't need all 6 filetypes searched for, and attempts to generate .fai, .chromSizes and .dict files from the .fa file.
  
If index is made then the folder name will have .starWithAnnIdx or .starIdx for -align starWithAnn and align star, respectively, allowing the folder to be properly identified next time if the align mode is appropriate to the index.